### PR TITLE
Prevent exceptions with "fileserver.update" when called via state

### DIFF
--- a/changelog/65819.fixed.md
+++ b/changelog/65819.fixed.md
@@ -1,1 +1,1 @@
-Allow keyword arguments for the fileserver roots backend update function.
+Prevent exceptions with fileserver.update when called via state

--- a/salt/fileserver/roots.py
+++ b/salt/fileserver/roots.py
@@ -138,16 +138,10 @@ def serve_file(load, fnd):
     return ret
 
 
-def update(**kwargs):
+def update():
     """
     When we are asked to update (regular interval) lets reap the cache
     """
-    # __pub_user responsible for the runner can be passed but we don't do anything with it
-    if "__pub_user" in kwargs:
-        del kwargs["__pub_user"]
-    if kwargs:
-        raise ValueError("Unexpected keyword arguments received: %s" % kwargs)
-
     try:
         salt.fileserver.reap_fileserver_cache_dir(
             os.path.join(__opts__["cachedir"], "roots", "hash"), find_file

--- a/salt/runners/fileserver.py
+++ b/salt/runners/fileserver.py
@@ -350,6 +350,12 @@ def update(backend=None, **kwargs):
         salt-run fileserver.update backend=git remotes=myrepo,yourrepo
     """
     fileserver = salt.fileserver.Fileserver(__opts__)
+
+    # Remove possible '__pub_user' in kwargs as it is not expected
+    # on "update" function for the different fileserver backends.
+    if "__pub_user" in kwargs:
+        del kwargs["__pub_user"]
+
     fileserver.update(back=backend, **kwargs)
     return True
 

--- a/tests/pytests/unit/fileserver/test_roots.py
+++ b/tests/pytests/unit/fileserver/test_roots.py
@@ -4,7 +4,6 @@
 
 import copy
 import pathlib
-import re
 import shutil
 import textwrap
 
@@ -278,9 +277,3 @@ def test_update_mtime_map_unicode_error(tmp_path):
         },
         "backend": "roots",
     }
-
-
-def test_update_unexpected_kwargs():
-    with pytest.raises(ValueError) as exc_info:
-        ret = roots.update(foo="bar")
-    assert re.match(r"Unexpected keyword arguments received:", str(exc_info.value))


### PR DESCRIPTION
This PR just takes a different approach to fix the issues with `__pub_user` being propagated to the `update()` method of the different fileserver backend.

Additionally, it fixes wrong asserts on `fileserver.update` tests, as it was producing false positives when `ret["return"]` is a string (i.a. when errors are produced) instead of `True` value.